### PR TITLE
Export TesseractDecoder from package

### DIFF
--- a/src/tesseract_decoder/__init__.py
+++ b/src/tesseract_decoder/__init__.py
@@ -2,8 +2,10 @@ from .core import (
     decode_from_circuit_file,
     decode_from_detection_events,
 )
+from .decoder import TesseractDecoder
 
 __all__ = [
     "decode_from_circuit_file",
     "decode_from_detection_events",
+    "TesseractDecoder",
 ]


### PR DESCRIPTION
## Summary
- re-export `TesseractDecoder` via `tesseract_decoder/__init__.py`

## Testing
- `PYTHONPATH=/tmp/stubs:src PATH=/tmp/tesseract_stub:$PATH python - <<'PY'
from tesseract_decoder import TesseractDecoder
print(TesseractDecoder)
print('Imported successfully')
PY`